### PR TITLE
Fix support for python 3

### DIFF
--- a/phpserialize.py
+++ b/phpserialize.py
@@ -519,15 +519,15 @@ def load(fp, charset='utf-8', errors=default_errors, decode_strings=False,
         raise ValueError('unexpected opcode - %s' % repr(type_))
 
     fp_position = fp.tell()
-    chunk = _read_until(':');
+    chunk = _read_until(b':');
     fp.seek(fp_position) # Reset pointer
-    if '|' in chunk:
+    if b'|' in chunk:
         # We may be dealing with a serialized session, in which case keys
         # followed by a pipe are preceding the serialized data.
         unserialized_data = {}
         while 1:
             try:
-                key = _read_until('|');
+                key = _read_until(b'|');
             except ValueError:
                 break # end of stream
             if return_unicode:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     name='phpserialize',
     author='Armin Ronacher',
     author_email='armin.ronacher@active-4.com',
-    version='1.5',
+    version='1.6',
     url='https://github.com/nathanwalsh/phpserialize',
     py_modules=['phpserialize'],
     description='a port of the serialize and unserialize '


### PR DESCRIPTION
- Add missing 'b's to string literals to ensure bytes are used
- Fix broken test
  - Was assuming the order of a serialized dictionary, even though
    dictionaries are not ordered
